### PR TITLE
feat: make model configurable via env

### DIFF
--- a/src/storymachine/cli.py
+++ b/src/storymachine/cli.py
@@ -46,7 +46,11 @@ def slugify(title: str) -> str:
 
 
 def get_context_enriched_stories(
-    client: OpenAI, prd_path: str, tech_spec_path: str, target_dir: str = "."
+    client: OpenAI,
+    prd_path: str,
+    tech_spec_path: str,
+    target_dir: str = ".",
+    model: str = "gpt-5",
 ) -> List[dict[str, str]]:
     """
     Process PRD and tech spec files to generate context-enriched stories.
@@ -56,6 +60,7 @@ def get_context_enriched_stories(
         prd_path: Path to the PRD file
         tech_spec_path: Path to the tech spec file
         target_dir: Target directory for generated story files (default: current directory)
+        model: The model to use (default: ``gpt-5``)
 
     Returns:
         List of generated story file names
@@ -64,7 +69,9 @@ def get_context_enriched_stories(
     prd_content = Path(prd_path).read_text()
     tech_spec_content = Path(tech_spec_path).read_text()
 
-    stories = stories_from_project_sources(client, prd_content, tech_spec_content)
+    stories = stories_from_project_sources(
+        client, prd_content, tech_spec_content, model
+    )
 
     def create_story_file(index: int, story) -> dict[str, str]:
         filename = f"{index:02d}-{slugify(story.title)}.md"
@@ -122,7 +129,11 @@ def main():
 
     with spinner("Machining Stories"):
         created_stories = get_context_enriched_stories(
-            client, str(prd_path), str(tech_spec_path), args.target_dir
+            client,
+            str(prd_path),
+            str(tech_spec_path),
+            args.target_dir,
+            settings.model,
         )
 
     for story in created_stories:

--- a/src/storymachine/config.py
+++ b/src/storymachine/config.py
@@ -4,3 +4,4 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     openai_api_key: str = Field(..., frozen=True, alias="OPENAI_API_KEY")
+    model: str = Field("gpt-5", alias="MODEL")

--- a/src/storymachine/story_machine.py
+++ b/src/storymachine/story_machine.py
@@ -25,13 +25,14 @@ def stories_from_tool_call(tool_call: ResponseFunctionToolCall) -> List[Story]:
 
 
 def stories_from_project_sources(
-    client: OpenAI, prd_content: str, tech_spec_content: str
+    client: OpenAI, prd_content: str, tech_spec_content: str, model: str
 ) -> List[Story]:
     """Generate stories from project sources.
 
     Args:
         prd_content (str): The content of the project requirements document.
         tech_spec_content (str): The content of the technical specification document.
+        model (str): The OpenAI model to use for story generation.
     Returns:
         List[Story]: A list of generated stories.
     """
@@ -84,7 +85,7 @@ Ensure that the stories follow the principles laid out in Mike Cohn's 'User Stor
 
     input_list: ResponseInputParam = [{"role": "user", "content": prompt}]
     response = client.responses.create(
-        model="gpt-5-nano",
+        model=model,
         tools=[create_stories_tool],
         input=input_list,
         tool_choice="required",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,3 +115,21 @@ class TestSettings:
 
         settings = Settings()  # pyright: ignore[reportCallIssue]
         assert settings.openai_api_key == "   "
+
+    def test_settings_default_model(self, monkeypatch) -> None:
+        """Test that model defaults when not provided."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.delenv("MODEL", raising=False)
+
+        settings = Settings()  # pyright: ignore[reportCallIssue]
+
+        assert settings.model == "gpt-5"
+
+    def test_settings_model_env_var(self, monkeypatch) -> None:
+        """Test that model can be set via environment variable."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("MODEL", "gpt-test")
+
+        settings = Settings()  # pyright: ignore[reportCallIssue]
+
+        assert settings.model == "gpt-test"

--- a/tests/test_story_machine.py
+++ b/tests/test_story_machine.py
@@ -61,7 +61,10 @@ class TestStoriesFromProjectSources:
         """Test successful story generation from project sources."""
 
         stories = stories_from_project_sources(
-            mock_openai_client, sample_prd_content, sample_tech_spec_content
+            mock_openai_client,
+            sample_prd_content,
+            sample_tech_spec_content,
+            "gpt-test",
         )
 
         assert len(stories) == 2
@@ -70,6 +73,7 @@ class TestStoriesFromProjectSources:
         mock_openai_client.responses.create.assert_called_once()
         call_args = mock_openai_client.responses.create.call_args
 
+        assert call_args.kwargs["model"] == "gpt-test"
         assert call_args.kwargs["tool_choice"] == "required"
         assert call_args.kwargs["tools"][0]["name"] == "create_stories"
 
@@ -82,7 +86,10 @@ class TestStoriesFromProjectSources:
         """Test that prompt contains project content."""
 
         stories_from_project_sources(
-            mock_openai_client, sample_prd_content, sample_tech_spec_content
+            mock_openai_client,
+            sample_prd_content,
+            sample_tech_spec_content,
+            "gpt-test",
         )
 
         call_args = mock_openai_client.responses.create.call_args


### PR DESCRIPTION
## Summary
- allow setting model via `MODEL` environment variable with default `gpt-5`
- thread model setting through CLI and story generation
- add tests for model configuration
- remove redundant model assertion from CLI test

## Testing
- `uv run --frozen ruff format .`
- `uv run --frozen pyright`
- `uv run --frozen ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD="" uv run --frozen pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1855f84e4832a9a14fed074916a35