### PR TITLE
Add Makefile with development workflow targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# StoryMachine Makefile
+# Self-documenting makefile - targets include usage descriptions
+
+.DEFAULT_GOAL := help
+.PHONY: help setup run clean build
+
+help: ## Display this help message
+	@echo "StoryMachine - Available targets:"
+	@echo
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+setup: ## Install uv if not present and sync dependencies
+	@if ! command -v uv >/dev/null 2>&1; then \
+		echo "Installing uv..."; \
+		curl -LsSf https://astral.sh/uv/install.sh | sh; \
+		echo "Please restart your shell or run: source ~/.bashrc"; \
+	else \
+		echo "uv is already installed"; \
+	fi
+	uv sync
+
+run: ## Run storymachine CLI (modify PRD and tech-spec paths as needed)
+	@echo "Example run - modify paths as needed:"
+	@echo "uv run storymachine --prd path/to/your/prd.md --tech-spec path/to/your/tech-spec.md"
+	@echo
+	@echo "Usage: uv run storymachine --help"
+	uv run storymachine --help
+
+clean: ## Remove Python cache files and build artifacts
+	@echo "Cleaning up Python artifacts..."
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete 2>/dev/null || true
+	rm -rf .pytest_cache .coverage dist/ .ruff_cache/
+	@echo "Clean complete"
+
+build: clean ## Clean, format, check types/lint, and run tests
+	@echo "Running build pipeline..."
+	uv run --frozen ruff format .
+	uv run --frozen ruff check . --fix
+	uv run --frozen pyright
+	uv run --frozen pytest
+	@echo "Build complete"

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ setup: ## Install uv if not present and sync dependencies
 	fi
 	uv sync
 
-run: ## Run storymachine CLI (modify PRD and tech-spec paths as needed)
-	@echo "Example run - modify paths as needed:"
-	@echo "uv run storymachine --prd path/to/your/prd.md --tech-spec path/to/your/tech-spec.md"
-	@echo
-	@echo "Usage: uv run storymachine --help"
-	uv run storymachine --help
+run: ## Run storymachine CLI with arguments (e.g., make run -- --prd file.md --tech-spec spec.md)
+	uv run storymachine $(filter-out $@,$(MAKECMDGOALS))
+
+# This allows arguments to be passed to the run target
+%:
+	@:
 
 clean: ## Remove Python cache files and build artifacts
 	@echo "Cleaning up Python artifacts..."


### PR DESCRIPTION
## Summary
- Add comprehensive Makefile with self-documenting help system
- Includes targets for setup, run, clean, and build workflows
- Follows project's uv-only package management approach

## Targets Added
- `help`: Display all available targets (default)
- `setup`: Install uv if needed and sync dependencies
- `run`: Execute storymachine CLI directly with argument pass-through
- `clean`: Remove Python cache and build artifacts  
- `build`: Complete pipeline (clean → format → check → test)

## Sample Output

### make help
```
StoryMachine - Available targets:

  help       Display this help message
  setup      Install uv if not present and sync dependencies
  run        Run storymachine CLI with arguments (e.g., make run -- --prd file.md --tech-spec spec.md)
  clean      Remove Python cache files and build artifacts
  build      Clean, format, check types/lint, and run tests
```

### make run
```bash
# Run without arguments (shows usage)
make run

# Run with arguments
make run -- --help
make run -- --prd myfile.md --tech-spec spec.md
```

### make build
```
Cleaning up Python artifacts...
Clean complete
Running build pipeline...
11 files left unchanged
All checks passed!
0 errors, 3 warnings, 0 informations
============================== 23 passed in 0.12s ==============================
Build complete
```

🤖 Generated with [Claude Code](https://claude.ai/code)