### PR TITLE
feat: Enhance story generation prompt with structured guidelines and controls

### DIFF
--- a/src/storymachine/story_machine.py
+++ b/src/storymachine/story_machine.py
@@ -36,20 +36,69 @@ def stories_from_project_sources(
     Returns:
         List[Story]: A list of generated stories.
     """
-    prompt = f"""Given the following project sources:
+    prompt = f"""<task>
+From the sources below, produce a list of user stories via the `create_stories` tool.
+</task>
 
+<sources>
 <project_requirements_document>
 {prd_content}
 </project_requirements_document>
-
 <technical_specification_document>
 {tech_spec_content}
 </technical_specification_document>
+</sources>
 
-Create a list of user stories using the create_stories tool.
+<coverage_plan>
+- Extract personas that appear in sources.
+- Extract all user-facing functional requirements and acceptance tests from sources into a capability list.
+- Remove items marked Non-goals or clearly NFR-only.
+- Produce one minimal, independent story per capability until all are covered. Split list vs detail, view vs edit, read vs write.
+- Include role/permission behaviors where specified (e.g., Admin vs Viewer) inside AC of relevant stories.
+- Treat PRD “Acceptance tests” as must-cover behaviors in stories or AC.
+- If tech spec adds user-visible behavior not in PRD, include it only if corroborated; otherwise exclude.
+</coverage_plan>
 
-Ensure that the stories follow the principles laid out in Mike Cohn's 'User Stories Applied'.
+<quality_bar>
+- Follow Mike Cohn’s user story principles and the INVEST heuristic.
+- Use real end-user personas that appear in the sources. No system/app/stakeholder actors.
+- Scope each story to one user-facing capability with clear business value.
+- Do not invent requirements. If something is not supported by the sources, omit it.
+- Keep stories independent and non-duplicative. Prefer vertical slices.
+</quality_bar>
+
+<acceptance_criteria_rules>
+- Use Given/When/Then. Behavior-focused only. No implementation details.
+- Metrics only if explicitly in sources. No arbitrary thresholds.
+- Cover primary flow and the key edge cases stated in sources.
+</acceptance_criteria_rules>
+
+<format>
+Return only a `create_stories` tool call with:
+- `title`: "As a <persona>, I want <capability> so that <benefit>."
+- `acceptance_criteria`: 3–6 items, each a single Given/When/Then line.
+No extra commentary or prose outside the tool call.
+</format>
+
+<controls>
+- Reason strictly from sources; use their terms.
+- Prefer smaller vertical slices. Avoid duplicates and overlaps.
+- For every story you include, be able to point to the exact source clause internally (do not output references).
+- Do not create stories for pure NFRs or release criteria; if an NFR shapes behavior, reflect it as observable behavior only.
+- Do not stop generating until every user-facing capability from the coverage_plan is represented by at least one story.
+</controls>
+
+<self_reflection>
+Internally check before emitting:
+1) Coverage: every user-facing capability and acceptance test from sources appears in exactly one story (or a clearly split pair) with no gaps.
+2) Persona: each title uses a real end-user persona from sources.
+3) Title: states capability and benefit.
+4) AC: behavioral, testable, grounded in sources; permissions included where specified.
+5) No duplicates/overlaps; split or merge as needed to satisfy INVEST.
+Do not output this reflection.
+</self_reflection>
 """
+
     create_stories_tool: ToolParam = {
         "type": "function",
         "name": "create_stories",
@@ -89,6 +138,8 @@ Ensure that the stories follow the principles laid out in Mike Cohn's 'User Stor
         tools=[create_stories_tool],
         input=input_list,
         tool_choice="required",
+        reasoning={"effort": "medium"},
+        text={"verbosity": "low"},
     )
 
     tool_calls = [


### PR DESCRIPTION
- Add detailed <task> and <sources> sections to clarify input context
- Define <coverage_plan> to ensure all user-facing capabilities are captured
- Introduce <quality_bar> for persona, scope, and INVEST compliance
- Specify <acceptance_criteria_rules> for behavior-focused AC format
- Enforce strict <controls> on source-based reasoning and story slicing
- Add internal <self_reflection> checks to validate output completeness
- Adjust LLM call parameters for medium effort and low verbosity

Eval Notes:

* Annotated "good story" percentage on Grand Central shot up from 66.7% to 83.3% with the new prompt.
* The new prompt produces half as many story cards. So there was a lot less to annotate.
* Given the low sample size, the percentage doesn’t matter as much as just the upward trend. This is not a very statistically significant increase from just the numbers alone, but the quality has improved from an “eye test”, see next point.
* Qualitatively, even though there were fewer story cards, they seemed overall better as a set, and a lot more negotiable and abstracted from technical specifics. This is fine because we will be layering implementation context on top of these cards in the next feature.
* The two examples that I marked as “not good” in my evals are actually very borderline not good. The mistakes in it are very subtle.