### PR TITLE
Fix: Add early target directory validation

### DIFF
--- a/src/storymachine/cli.py
+++ b/src/storymachine/cli.py
@@ -127,6 +127,15 @@ def main():
         print(f"Error: Tech spec file not found: {tech_spec_path}", file=sys.stderr)
         sys.exit(1)
 
+    target_path = Path(args.target_dir)
+    if not target_path.exists():
+        print(f"Error: Target directory not found: {target_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not target_path.is_dir():
+        print(f"Error: Target path is not a directory: {target_path}", file=sys.stderr)
+        sys.exit(1)
+
     with spinner("Machining Stories"):
         created_stories = get_context_enriched_stories(
             client,


### PR DESCRIPTION
## Summary
- Add validation for target directory existence and type before story generation
- Prevents failure after generating stories when target directory is invalid
- Follows existing pattern of early validation for input files

## Test plan
- [x] Test with non-existent target directory - fails early with clear error
- [x] Test with file instead of directory as target - fails early with clear error  
- [x] Verify existing functionality works with valid target directory - passes validation

🤖 Generated with [Claude Code](https://claude.ai/code)